### PR TITLE
Vail-5668: Support cross compilation with rrdtool (FreeBSD 12.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To build:
 
 Example:
 
-    docker build -t spectralogic/freebsd-cross-build:12.1 .
+    docker build -t spectralogic/freebsd-cross-build:12.3 .
 
 To run:
 

--- a/freebsd-toolchain.sh
+++ b/freebsd-toolchain.sh
@@ -5,7 +5,7 @@ set -eux
 
 arch=$1
 binutils_version=2.34
-freebsd_version=12.1
+freebsd_version=12.3
 triple=$arch-unknown-freebsd12
 sysroot=/usr/local/$triple
 
@@ -50,10 +50,10 @@ files_to_extract=(
 "./usr/lib/*crt*.o"
 )
 # Try to unpack only the libraries the build needs, to save space.
-for lib in c cxxrt gcc_s m thr util; do
+for lib in c cxxrt gcc_s m thr util md z; do
   files_to_extract=("${files_to_extract[@]}" "./lib/lib${lib}.*" "./usr/lib/lib${lib}.*")
 done
-for lib in c++ c_nonshared compiler_rt execinfo gcc pthread rt ssp_nonshared; do
+for lib in c++ c_nonshared compiler_rt execinfo gcc pthread rt ssp_nonshared bz2 dl lzma wrap; do
   files_to_extract=("${files_to_extract[@]}" "./usr/lib/lib${lib}.*")
 done
 

--- a/freebsd-toolchain.sh
+++ b/freebsd-toolchain.sh
@@ -57,7 +57,7 @@ for lib in c++ c_nonshared compiler_rt execinfo gcc pthread rt ssp_nonshared; do
   files_to_extract=("${files_to_extract[@]}" "./usr/lib/lib${lib}.*")
 done
 
-URL=http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/${freebsd_arch}/${freebsd_version}-RELEASE/base.txz
+URL=https://archive.freebsd.org/old-releases/${freebsd_arch}/${freebsd_version}-RELEASE/base.txz
 curl "$URL" | tar xJf - -C "$sysroot" --wildcards "${files_to_extract[@]}"
 
 # Clang can do cross-builds out of the box, if we give it the right


### PR DESCRIPTION
To support cross compilation to freeBSD when using the rrd go library (to be added soon to go-core), we need to bump to freeBSD 12.3 (at a minimum) and add the following libraries from the base install:

* bz2
* dl
* lzma
* md
* wrap
* z